### PR TITLE
修正README中描述错误部分

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Can more easily realize C2Profile configuration and custom communication protoco
 
 1. Generate beacon of `Linux-bind` / `MacOS-bind` type
 2. The target in the intranet runs `./MacOS-bind.beacon <port>` to start the service
-3. Run `connect <targetIP>:<port>` in the session of China Unicom
+3. Run `connect <targetIP> <port>` in the session of China Unicom
 
 
 ## Run script in memory

--- a/README_zh.md
+++ b/README_zh.md
@@ -120,7 +120,7 @@
 
 1. 生成 `Linux-bind` / `MacOS-bind` 类型的beacon
 2. 内网中的目标运行 `./MacOS-bind.beacon <port>` 开启服务
-3. 在网络联通的session中运行 `connect <targetIP>:<port>`
+3. 在网络联通的session中运行 `connect <targetIP> <port>`
 
 ## 内存中运行脚本
 


### PR DESCRIPTION
连接时不加:号

![image](https://user-images.githubusercontent.com/30547741/126034702-d1829e4e-3c7f-4ca2-a8c6-0f1e5bfbdd75.png)

连接时加:号，会吧默认的4444也加上去。

![image](https://user-images.githubusercontent.com/30547741/126034706-7325ab67-7366-498b-81ff-6d9f5a91ac9c.png)